### PR TITLE
feat: allow pass extra modules

### DIFF
--- a/R/md-board.R
+++ b/R/md-board.R
@@ -4,14 +4,22 @@
 #'
 #' @param ... Board attributes
 #' @param document Initial document
+#' @param modules Additional modules to add to the board. See [blockr.ui::new_chat_module()].
 #' @param pptx_template Path to a PowerPoint template.
 #'
 #' @export
-new_md_board <- function(..., document = character(), pptx_template = NULL) {
-
+new_md_board <- function(
+  ...,
+  document = character(),
+  modules = list(),
+  pptx_template = NULL
+) {
   blockr.ui::new_dag_board(
     ...,
-    modules = new_md_module(content = document, pptx_template = pptx_template),
+    modules = c(
+      list(new_md_module(content = document, pptx_template = pptx_template)),
+      modules
+    ),
     class = "md_board"
   )
 }

--- a/man/new_md_board.Rd
+++ b/man/new_md_board.Rd
@@ -15,7 +15,12 @@
 \alias{gen_md_ui}
 \title{Markdown board}
 \usage{
-new_md_board(..., document = character(), pptx_template = NULL)
+new_md_board(
+  ...,
+  document = character(),
+  modules = list(),
+  pptx_template = NULL
+)
 
 md_render(x, value, dir = tempdir(), ...)
 
@@ -41,6 +46,8 @@ gen_md_ui(content = character())
 \item{...}{Board attributes}
 
 \item{document}{Initial document}
+
+\item{modules}{Additional modules to add to the board. See \code{\link[blockr.ui:board-module]{blockr.ui::new_chat_module()}}.}
 
 \item{pptx_template}{Path to custom PowerPoint template. Default is NULL}
 


### PR DESCRIPTION
@nbenn `new_md_board` probably wants to have `new_md_module(content = document, pptx_template = pptx_template)` as a default internal module. This PR allows to pass other modules to it like the ai chat module, which is currently not shipped with `new_dag_board` due to various issues (see https://github.com/BristolMyersSquibb/blockr.ui/issues/83#issue-3299393212).

We can then do:

```r
library(blockr.core)
library(blockr.md)

serve(
  blockr.md::new_md_board(
    document = c(
      "# Clinical Trial Report",
      "",
      "## Demographics Table",
      "![Summary table from both RTF sources](blockr://table)",
      "",
      "## Dataset 1 Results",
      "![Week 12, ACR 50](blockr://plot1)",
      "",
      "## Dataset 2 Results",
      "![Week 12, ACR 70](blockr://plot2)",
      "",
      "## Conclusions",
      "Analysis conclusions here",
      "",
      "---",
      "*Generated using blockr framework*"
    ),
    modules = list(
      chat = new_chat_module()
    )
  )
)
```