### PR TITLE
Use on_restore hook

### DIFF
--- a/R/md-module.R
+++ b/R/md-module.R
@@ -4,6 +4,18 @@ new_md_module <- function(id = "document", title = "Document builder",
   blockr.ui::new_board_module(
     gen_md_ui(content),
     gen_md_server(pptx_template),
+    on_restore = function(board, parent, session, ...) {
+
+      req(parent$module_state$document())
+
+      shinyAce::updateAceEditor(
+        session,
+        "ace",
+        parent$module_state$document()
+      )
+
+      invisible()
+    },
     id = id,
     title = title,
     class = "md_module"

--- a/R/md-server.R
+++ b/R/md-server.R
@@ -25,18 +25,6 @@ gen_md_server <- function(pptx_template = NULL) {
 
         observeEvent(input$ace, res(input$ace))
 
-        observeEvent(
-          req(parent$refreshed == "restore-network"),
-          {
-            req(parent$module_state$document())
-            shinyAce::updateAceEditor(
-              session,
-              "ace",
-              parent$module_state$document()
-            )
-          }
-        )
-
         ast <- tempfile(fileext = ".json")
         tmp <- tempfile()
 
@@ -109,12 +97,15 @@ gen_md_server <- function(pptx_template = NULL) {
 
             pandoc_opts <- NULL
 
-            # Determine which template to use: custom upload > function parameter > selected bundled template
+            # Determine which template to use: custom upload > function
+            # parameter > selected bundled template
             template_path <- NULL
-            
-            if (isTruthy(input$use_custom_template) && isTruthy(input$template)) {
-              # Custom uploaded template (only if checkbox is checked and file is uploaded)
-              template_path <- input$template$datapath
+            inp_temp <- input$template
+
+            if (isTruthy(input$use_custom_template) && isTruthy(inp_temp)) {
+              # Custom uploaded template (only if checkbox is checked and file
+              # is uploaded)
+              template_path <- inp_temp$datapath
             } else if (length(pptx_template)) {
               # Function parameter template
               template_path <- pptx_template
@@ -126,7 +117,7 @@ gen_md_server <- function(pptx_template = NULL) {
             if (!is.null(template_path)) {
               trg <- file.path(dirname(file), "template.pptx")
               file.copy(template_path, trg, overwrite = TRUE)
-              
+
               on.exit(unlink(trg))
 
               pandoc_opts <- c(

--- a/R/md-server.R
+++ b/R/md-server.R
@@ -3,14 +3,13 @@
 #' @rdname new_md_board
 #' @export
 gen_md_server <- function(pptx_template = NULL) {
-
   if (length(pptx_template)) {
     pptx_template <- normalizePath(pptx_template, mustWork = TRUE)
   }
 
-  function(board, update, session, parent, ...) {
+  function(id, board, update, session, parent, ...) {
     moduleServer(
-      "doc",
+      id,
       function(input, output, session) {
         observeEvent(
           get_board_option_or_default("dark_mode"),
@@ -94,7 +93,6 @@ gen_md_server <- function(pptx_template = NULL) {
             )
           },
           function(file) {
-
             pandoc_opts <- NULL
 
             # Determine which template to use: custom upload > function

--- a/R/md-ui.R
+++ b/R/md-ui.R
@@ -37,11 +37,11 @@ get_default_template <- function() {
 #' @export
 gen_md_ui <- function(content = character()) {
   function(id, board, ...) {
-    id <- NS(id, "doc")
+    ns <- NS(id)
 
     tagList(
       shinyAce::aceEditor(
-        NS(id, "ace"),
+        ns("ace"),
         content,
         mode = "markdown"
       ),
@@ -49,14 +49,14 @@ gen_md_ui <- function(content = character()) {
         class = "d-flex align-items-center",
 
         selectInput(
-          NS(id, "template_select"),
+          ns("template_select"),
           NULL,
           choices = get_template_choices(),
           selected = get_default_template(),
           width = "100%"
         ),
         actionButton(
-          NS(id, "render"),
+          ns("render"),
           "Render",
           class = "btn-success btn-sm",
           style = "margin-left: 10px; margin-top: -18px; height: 36px;"
@@ -65,14 +65,14 @@ gen_md_ui <- function(content = character()) {
       div(
         class = "mb-3",
         checkboxInput(
-          NS(id, "use_custom_template"),
+          ns("use_custom_template"),
           tags$small(class = "text-muted", "Use custom template"),
           value = FALSE
         ),
         conditionalPanel(
-          condition = paste0("input['", NS(id, "use_custom_template"), "']"),
+          condition = paste0("input['", ns("use_custom_template"), "']"),
           fileInput(
-            NS(id, "template"),
+            ns("template"),
             NULL,
             placeholder = "Select .pptx template file",
             accept = ".pptx"


### PR DESCRIPTION
Closes #12.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Editor content is automatically restored when reopening the board, so you can pick up where you left off.
  * Improved template handling for exports: uses your uploaded template when provided, falls back to the default, or lets you choose from bundled options.

* **Bug Fixes**
  * More reliable editor state during restoration, reducing cases where content failed to appear after returning to the board.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->