### PR TITLE
Multi-format render: PDF and HTML in addition to PPTX

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,7 +28,8 @@ Imports:
     flextable,
     later
 Suggests:
-    pdftools
+    pdftools,
+    tinytex
 Remotes:
     BristolMyersSquibb/blockr.core,
     BristolMyersSquibb/blockr.dock

--- a/R/md-render-format.R
+++ b/R/md-render-format.R
@@ -1,0 +1,22 @@
+render_format <- function(ast, format, template, output) {
+  format <- match.arg(format, supported_formats())
+
+  pandoc_opts <- get_pandoc_args(format)
+
+  if (!is.null(template) && nzchar(template)) {
+    trg <- file.path(dirname(output), basename(template))
+    file.copy(template, trg, overwrite = TRUE)
+    on.exit(unlink(trg), add = TRUE)
+
+    flag <- if (identical(format, "pptx")) "--reference-doc=" else "--template="
+    pandoc_opts <- c(paste0(flag, basename(trg)), pandoc_opts)
+  }
+
+  rmarkdown::pandoc_convert(
+    input   = ast,
+    from    = "json",
+    to      = format_pandoc_to(format),
+    output  = output,
+    options = pandoc_opts
+  )
+}

--- a/R/md-server.R
+++ b/R/md-server.R
@@ -106,8 +106,45 @@ gen_md_server <- function(id, board, update, session, parent, ...) {
         )
       )
 
+      current_format <- reactive({
+        fmt <- input$format_select
+        if (!isTruthy(fmt)) "pptx" else fmt
+      })
+
+      output$template_select_ui <- renderUI({
+        fmt <- current_format()
+        selectInput(
+          session$ns("template_select"),
+          NULL,
+          choices  = get_template_choices(fmt),
+          selected = get_default_template(fmt),
+          width = "100%"
+        )
+      })
+
+      output$custom_template_ui <- renderUI({
+        fmt <- current_format()
+        ext <- paste0(".", format_ext(fmt))
+        fileInput(
+          session$ns("template"),
+          NULL,
+          placeholder = paste0("Select ", ext, " template file"),
+          accept = ext
+        )
+      })
+
+      output$pdf_unavailable_note <- renderUI({
+        if (pdf_available()) return(NULL)
+        div(
+          class = "text-muted",
+          style = "margin-top: -6px; margin-bottom: 8px; font-size: 0.8rem;",
+          tags$small("PDF unavailable on this server (install tinytex).")
+        )
+      })
+
       res_tpl <- reactive(
         {
+          fmt <- current_format()
           inp_temp <- input$template
 
           if (isTruthy(input$use_custom_template) && isTruthy(inp_temp)) {
@@ -115,7 +152,7 @@ gen_md_server <- function(id, board, update, session, parent, ...) {
           } else if (isTruthy(input$template_select)) {
             input$template_select
           } else {
-            pkg_file("templates", "pandoc-default.pptx")
+            default_template(fmt)[[1L]]
           }
         }
       )
@@ -201,29 +238,29 @@ gen_md_server <- function(id, board, update, session, parent, ...) {
         )
       })
 
-      output$dl_ppt <- downloadHandler(
+      output$dl <- downloadHandler(
         filename = function() {
+          fmt <- current_format()
           paste0(
             "topline_",
             format(Sys.time(), "%Y-%m-%d_%H-%M-%S"),
-            ".pptx"
+            ".",
+            format_download_ext(fmt)
           )
         },
         content = function(file) {
           req(input$ace)
+          fmt <- current_format()
 
-          # Create temp files for processing
           ast <- tempfile(fileext = ".json")
           tmp <- tempfile()
           dir.create(tmp)
 
-          # Ensure cleanup
           on.exit({
             unlink(ast)
             unlink(tmp, recursive = TRUE)
           })
 
-          # Process markdown to AST
           filter_md(
             block_filter,
             blocks = lst_xtr(board$blocks, "server", "result"),
@@ -232,30 +269,11 @@ gen_md_server <- function(id, board, update, session, parent, ...) {
             output = ast
           )
 
-          # Determine which template to use: custom upload > function
-          # parameter > selected bundled template
-          pandoc_opts <- NULL
-          template_path <- res_tpl()
-
-          if (!is.null(template_path)) {
-            trg <- file.path(dirname(file), "template.pptx")
-            file.copy(template_path, trg, overwrite = TRUE)
-
-            on.exit(unlink(trg), add = TRUE)
-
-            pandoc_opts <- c(
-              paste0("--reference-doc=", basename(trg)),
-              "--slide-level=2"
-            )
-          }
-
-          # Convert AST to PowerPoint
-          rmarkdown::pandoc_convert(
-            input = ast,
-            from = "json",
-            to = "pptx",
-            output = file,
-            options = pandoc_opts
+          render_format(
+            ast = ast,
+            format = fmt,
+            template = res_tpl(),
+            output = file
           )
         }
       )

--- a/R/md-ui.R
+++ b/R/md-ui.R
@@ -10,7 +10,7 @@ gen_md_ui <- function(content = character()) {
           display: none !important;
         }
       ",
-        ns("dl_ppt")
+        ns("dl")
       ))),
       shinyAce::aceEditor(
         ns("ace"),
@@ -30,21 +30,25 @@ gen_md_ui <- function(content = character()) {
       uiOutput(ns("validation_message")),
       div(
         class = "d-flex align-items-center",
-
         selectInput(
-          ns("template_select"),
+          ns("format_select"),
           NULL,
-          choices = get_template_choices(),
-          selected = get_default_template(),
-          width = "100%"
+          choices = available_formats(),
+          selected = "pptx",
+          width = "100px"
+        ),
+        div(
+          style = "margin-left: 8px; flex: 1;",
+          uiOutput(ns("template_select_ui"))
         ),
         downloadButton(
-          ns("dl_ppt"),
+          ns("dl"),
           "Download",
           class = "btn-outline-success btn-sm",
           style = "margin-left: 10px; margin-top: -18px; height: 36px; padding-top: 6.5px;"
         )
       ),
+      uiOutput(ns("pdf_unavailable_note")),
       div(
         class = "mb-3",
         checkboxInput(
@@ -54,12 +58,7 @@ gen_md_ui <- function(content = character()) {
         ),
         conditionalPanel(
           condition = paste0("input['", ns("use_custom_template"), "']"),
-          fileInput(
-            ns("template"),
-            NULL,
-            placeholder = "Select .pptx template file",
-            accept = ".pptx"
-          )
+          uiOutput(ns("custom_template_ui"))
         )
       )
     )

--- a/R/templates.R
+++ b/R/templates.R
@@ -1,23 +1,72 @@
-get_template_choices <- function() {
-  get_template_opts()
+supported_formats <- function() c("pptx", "pdf", "html")
+
+format_ext <- function(format) {
+  c(pptx = "pptx", pdf = "tex", html = "html")[[format]]
 }
 
-get_default_template <- function() {
-  names(get_template_opts())[1L]
+format_pandoc_to <- function(format) {
+  c(pptx = "pptx", pdf = "latex", html = "html5")[[format]]
 }
 
-get_template_opts <- function() {
-  blockr_option("md_template", default_template())
+format_download_ext <- function(format) {
+  c(pptx = "pptx", pdf = "pdf", html = "html")[[format]]
+}
+
+get_template_choices <- function(format = "pptx") {
+  get_template_opts(format)
+}
+
+get_default_template <- function(format = "pptx") {
+  names(get_template_opts(format))[1L]
+}
+
+get_template_opts <- function(format = "pptx") {
+  opt <- if (identical(format, "pptx")) "md_template" else paste0("md_template_", format)
+  blockr_option(opt, default_template(format))
+}
+
+get_pandoc_args <- function(format) {
+  defaults <- list(
+    pptx = c("--slide-level=2"),
+    pdf  = character(),
+    html = c("--standalone", "--embed-resources")
+  )
+  blockr_option(paste0("md_pandoc_args_", format), defaults[[format]])
 }
 
 #' Default template option
 #'
-#' @return Named character vector for the default template
+#' For `pptx` returns the bundled reference-doc. For `pdf` and `html` returns
+#' the empty string — pandoc then uses its own built-in template, which always
+#' matches the installed pandoc version (avoids macro-skew errors like
+#' undefined `\pandocbounded` when the bundled template predates the pandoc
+#' producing the document).
+#'
+#' @param format One of `"pptx"`, `"pdf"`, `"html"`.
+#' @return Named character vector.
 #'
 #' @examples
 #' default_template()
+#' default_template("pdf")
 #'
 #' @export
-default_template <- function() {
-  c(`Pandoc Default` = pkg_file("templates", "pandoc-default.pptx"))
+default_template <- function(format = "pptx") {
+  format <- match.arg(format, supported_formats())
+  if (identical(format, "pptx")) {
+    c(`Pandoc Default` = pkg_file("templates", "pandoc-default.pptx"))
+  } else {
+    c(`Pandoc Default` = "")
+  }
+}
+
+pdf_available <- function() {
+  nzchar(Sys.which("pdflatex")) ||
+    nzchar(Sys.which("xelatex")) ||
+    (requireNamespace("tinytex", quietly = TRUE) && tinytex::is_tinytex())
+}
+
+available_formats <- function() {
+  fmts <- supported_formats()
+  if (!pdf_available()) fmts <- setdiff(fmts, "pdf")
+  fmts
 }

--- a/dev/app.R
+++ b/dev/app.R
@@ -1,0 +1,34 @@
+pkgload::load_all("blockr.core")
+pkgload::load_all("blockr.dock")
+pkgload::load_all("blockr.dag")
+pkgload::load_all("blockr.ui")
+pkgload::load_all("blockr.md")
+
+library(blockr)
+
+# options(shiny.port = 3838, shiny.host = "0.0.0.0")
+
+run_app(
+  blocks = c(
+    a = new_dataset_block("mtcars"),
+    b = new_scatter_block("disp", "hp")
+  ),
+  links = list(from = "a", to = "b", input = "data"),
+  extensions = list(
+    dag = new_dag_extension(),
+    doc = new_md_extension(
+      c(
+        "# My title",
+        "",
+        "## Slide with table",
+        "",
+        "![](blockr://a)",
+        "",
+        "## Slide with plot",
+        "",
+        "![Displacement vs. horsepower](blockr://b)",
+        ""
+      )
+    )
+  )
+)

--- a/dev/check-pdf.R
+++ b/dev/check-pdf.R
@@ -1,0 +1,68 @@
+cat("--- system ---\n")
+cat("OS:        ", Sys.info()[["sysname"]], Sys.info()[["release"]], "\n")
+cat("R:         ", R.version.string, "\n")
+cat("PATH:      ", Sys.getenv("PATH"), "\n\n")
+
+cat("--- LaTeX engines ---\n")
+for (eng in c("pdflatex", "xelatex", "lualatex")) {
+  p <- Sys.which(eng)
+  cat(sprintf("%-9s: %s\n", eng, if (nzchar(p)) p else "NOT FOUND"))
+}
+
+cat("\n--- tinytex ---\n")
+have_tinytex <- requireNamespace("tinytex", quietly = TRUE)
+cat("tinytex installed:", have_tinytex, "\n")
+if (have_tinytex) {
+  cat("tinytex::is_tinytex():", tinytex::is_tinytex(), "\n")
+  cat("tinytex::tinytex_root():", tryCatch(tinytex::tinytex_root(), error = function(e) "ERROR"), "\n")
+}
+
+cat("\n--- pandoc ---\n")
+cat("pandoc:", Sys.which("pandoc"), "\n")
+cat("rmarkdown::pandoc_version():", as.character(rmarkdown::pandoc_version()), "\n")
+
+cat("\n--- step 1: pandoc md -> pdf (no template, default engine) ---\n")
+mdf <- tempfile(fileext = ".md")
+writeLines("# Hi\n\nHello.\n", mdf)
+out1 <- tempfile(fileext = ".pdf")
+res1 <- tryCatch(
+  rmarkdown::pandoc_convert(input = mdf, to = "latex", output = out1),
+  error = function(e) conditionMessage(e),
+  warning = function(w) conditionMessage(w)
+)
+cat("result:", if (is.null(res1)) "OK" else res1, "\n")
+cat("file size:", if (file.exists(out1)) file.info(out1)$size else NA, "\n")
+
+cat("\n--- step 2: pandoc md -> pdf with --pdf-engine=xelatex ---\n")
+out2 <- tempfile(fileext = ".pdf")
+res2 <- tryCatch(
+  rmarkdown::pandoc_convert(input = mdf, to = "latex", output = out2,
+                            options = c("--pdf-engine=xelatex")),
+  error = function(e) conditionMessage(e)
+)
+cat("result:", if (is.null(res2)) "OK" else res2, "\n")
+cat("file size:", if (file.exists(out2)) file.info(out2)$size else NA, "\n")
+
+cat("\n--- step 3: render_format via blockr.md ---\n")
+if (requireNamespace("blockr.md", quietly = TRUE)) {
+  cat("blockr.md::pdf_available():", blockr.md:::pdf_available(), "\n")
+  ast <- tempfile(fileext = ".json")
+  rmarkdown::pandoc_convert(input = mdf, from = "markdown", to = "json", output = ast)
+  out3 <- tempfile(fileext = ".pdf")
+  res3 <- tryCatch(
+    blockr.md:::render_format(ast, "pdf",
+      template = blockr.md::default_template("pdf")[[1]],
+      output = out3),
+    error = function(e) conditionMessage(e)
+  )
+  cat("result:", if (is.null(res3)) "OK" else res3, "\n")
+  cat("file size:", if (file.exists(out3)) file.info(out3)$size else NA, "\n")
+} else {
+  cat("blockr.md not installed; skipping.\n")
+}
+
+cat("\n--- done ---\n")
+cat("If any step shows a LaTeX error, paste the full message.\n")
+cat("If pdflatex is NOT FOUND but tinytex is_tinytex() is TRUE, you probably need\n")
+cat("to add ~/Library/TinyTeX/bin/<arch>-darwin to PATH (or run\n")
+cat("tinytex::r_texmf() from R, then restart R).\n")

--- a/dev/issue-multi-format.md
+++ b/dev/issue-multi-format.md
@@ -1,0 +1,51 @@
+## Summary
+
+Extend the markdown builder to emit **PDF** and **HTML** in addition to the existing PPTX output. Format becomes an end-user-selectable control on the md block; theming for each format is plugged in via `options()` the same way `blockr.md_template` already works for pptx.
+
+DOCX is out of scope for now.
+
+## Motivation
+
+Today blockr.md only outputs PPTX. Users (mostly clinical/topline workflows) regularly ask for PDF — standard distribution format for reports. HTML is essentially free from pandoc once the dispatch layer exists and may sidestep a chunk of the PDF/LaTeX headache.
+
+Nicolas is owner of blockr.md but bandwidth-constrained, so we wanted a tight spec + thin prototype on a branch that he can review, push back on, or take over. The spec is at [`blockr.design/open/md-multi-format/`](../../../blockr.design/tree/main/open/md-multi-format). The prototype is on branch `feat/multi-format` (commit f00f865).
+
+## Design (short version)
+
+- **One render block, format picker added.** New `selectInput` with `pptx` / `pdf` / `html`. Existing template selector becomes format-aware via `renderUI`. Single Download button; filename + MIME derive from the selected format.
+- **Engine: pandoc via `rmarkdown::pandoc_convert`.** No new system dependency on Connect — pandoc is already there. Quarto was considered and rejected because we can't assume a working quarto install on locked-down corporate Connect.
+- **Per-format theming via `options()`**, mirroring the existing `blockr.md_template` (pptx) pattern:
+  - `blockr.md_template_pdf`  — named char vector
+  - `blockr.md_template_html` — named char vector
+  - `blockr.md_pandoc_args_{pptx,pdf,html}` — extra pandoc args (e.g. `--pdf-engine=xelatex`)
+  Downstream apps (blockr.topline-style) override these to inject branded templates.
+- **PDF fallback.** At session start, probe for `pdflatex`/`xelatex`/`tinytex::is_tinytex()`. If unavailable, `pdf` is hidden from the format picker and a muted note explains why. PPTX and HTML stay selectable. No silent format fallback.
+- **No bundled tex/html templates.** Empty default path = pandoc uses its own built-in template, which always matches the installed pandoc version. (Initial prototype bundled `pandoc -D latex` output, which caused `! Undefined control sequence \pandocbounded` on machines with pandoc ≥ 3.2 — that's exactly the version-skew we want to avoid.) PPTX still ships its bundled reference-doc, because pptx reference-docs don't have this problem.
+- **Cross-format table parity is a non-goal.** `flextable` stays pptx-flavored. For PDF/HTML the builder picks an appropriate table block (`gt` is the expected one). The render block doesn't try to translate.
+
+## Surface changes
+
+- `R/templates.R` — `get_template_choices(format)`, `default_template(format)`, `get_template_opts(format)`, `get_pandoc_args(format)`, `pdf_available()`, `available_formats()`.
+- `R/md-render-format.R` — new, single `render_format(ast, format, template, output)` dispatcher.
+- `R/md-ui.R` — format `selectInput`, reactive template selector, reactive file-input `accept`, PDF-unavailable note.
+- `R/md-server.R` — `output$dl` (renamed from `dl_ppt`), format-aware filename, calls `render_format`.
+- `DESCRIPTION` — `tinytex` added to `Suggests`.
+- `dev/app.R`, `dev/check-pdf.R` — runnable example + PDF-availability diagnostic.
+
+## What works
+
+- HTML and PDF render through the full Shiny pipeline (table + plot blocks embedded), verified on macOS + container.
+- PPTX path is regression-free.
+- BMS/customer-template override works the same way as for pptx today.
+
+## Open questions for review
+
+- Default format. Currently `pptx` to preserve current behavior; revisit once PDF stabilizes.
+- Placement of the format picker (currently inside the block UI next to the template picker; could move to dock chrome).
+- Custom-template upload behavior when the user switches formats mid-session. Current sketch lets the upload stick across format changes; clearing might be cleaner.
+
+## Status
+
+- Spec: [`blockr.design/open/md-multi-format/`](../../../blockr.design/tree/main/open/md-multi-format) (4 phases).
+- Prototype: branch `feat/multi-format`, commit f00f865, not pushed yet.
+- Happy to hand off to Nicolas — flagging this issue so it's tracked rather than living in a branch nobody sees.

--- a/man/default_template.Rd
+++ b/man/default_template.Rd
@@ -4,15 +4,23 @@
 \alias{default_template}
 \title{Default template option}
 \usage{
-default_template()
+default_template(format = "pptx")
+}
+\arguments{
+\item{format}{One of \code{"pptx"}, \code{"pdf"}, \code{"html"}.}
 }
 \value{
-Named character vector for the default template
+Named character vector.
 }
 \description{
-Default template option
+For \code{pptx} returns the bundled reference-doc. For \code{pdf} and \code{html} returns
+the empty string — pandoc then uses its own built-in template, which always
+matches the installed pandoc version (avoids macro-skew errors like
+undefined \verb{\\pandocbounded} when the bundled template predates the pandoc
+producing the document).
 }
 \examples{
 default_template()
+default_template("pdf")
 
 }


### PR DESCRIPTION
Refs #21.

## Summary

- Adds a format picker (`pptx` / `pdf` / `html`) to the md block.
- New `render_format()` dispatcher routes through `rmarkdown::pandoc_convert`.
- Per-format theming via `options()` (`blockr.md_template_pdf`, `blockr.md_template_html`, `blockr.md_pandoc_args_{pptx,pdf,html}`), mirroring the existing `blockr.md_template` pattern for pptx.
- PDF probe at session start (`pdflatex` / `xelatex` / `tinytex::is_tinytex()`); when LaTeX is unavailable, `pdf` is hidden from the picker and a muted note explains why.
- No bundled tex/html templates — empty path = pandoc uses its built-in template (avoids the `\pandocbounded` macro-skew we hit on pandoc 3.9 with a 3.1-bundled tex template). PPTX still ships its bundled reference-doc.

Full design and motivation in #21 and in [`blockr.design/open/md-multi-format/`](https://github.com/blockr-org/blockr.design/tree/main/open/md-multi-format).

## Test plan

- [ ] `devtools::load_all()` then run `dev/app.R`; verify the format picker shows all three options on a machine with LaTeX.
- [ ] Download each format (PPTX / PDF / HTML) from the app and open it — content should include a dataset table + scatter plot.
- [ ] On a machine without LaTeX, confirm `pdf` is hidden and the muted note appears; PPTX + HTML still work.
- [ ] Regression: PPTX with a custom `pptx_template` upload still applies the template.
- [ ] (Optional) Add unit tests under `tests/testthat/` for `default_template(format)` and `render_format()` round-trips (skip PDF when `!pdf_available()`).

Draft — leaving open for Nicolas to review / take over.