### PR TITLE
Make markdown content externally controllable via reactiveVal

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,8 +27,7 @@ Imports:
     magick,
     evaluate,
     blockr.dock,
-    flextable,
-    later
+    flextable
 Suggests:
     pdftools,
     testthat (>= 3.0.0)

--- a/R/md-ext.R
+++ b/R/md-ext.R
@@ -9,10 +9,11 @@
 new_md_extension <- function(content = character(), ...) {
 
   blockr.dock::new_dock_extension(
-    gen_md_server,
+    gen_md_server(content),
     gen_md_ui(content),
     name = "Document",
     class = "md_extension",
+    external_ctrl = "content",
     ...
   )
 }

--- a/R/md-server.R
+++ b/R/md-server.R
@@ -1,25 +1,29 @@
-gen_md_server <- function(id, board, update, session, parent, ...) {
-  moduleServer(
-    id,
-    function(input, output, session) {
-      # Reactive value to store available block IDs
-      available_block_ids <- reactiveVal(character())
+gen_md_server <- function(content = character()) {
 
-      # Reactive value for validation message
-      validation_message <- reactiveVal("")
+  function(id, board, update, session, parent, ...) {
+    moduleServer(
+      id,
+      function(input, output, session) {
+        # Reactive value to store available block IDs
+        available_block_ids <- reactiveVal(character())
 
-      # Fix horizontal scrolling on initial load
-      observe(
-        {
-          editor_id <- session$ns("ace")
+        # Reactive value for validation message
+        validation_message <- reactiveVal("")
 
-          # Insert JavaScript to force word wrap and resize editor
-          shiny::insertUI(
-            selector = "body",
-            where = "beforeEnd",
-            immediate = TRUE,
-            ui = tags$script(HTML(sprintf(
-              "
+        content_rv <- reactiveVal(content)
+
+        # Fix horizontal scrolling on initial load
+        observe(
+          {
+            editor_id <- session$ns("ace")
+
+            # Insert JavaScript to force word wrap and resize editor
+            shiny::insertUI(
+              selector = "body",
+              where = "beforeEnd",
+              immediate = TRUE,
+              ui = tags$script(HTML(sprintf(
+                "
             (function() {
               function setupEditor() {
                 if (typeof ace === 'undefined') {
@@ -46,225 +50,242 @@ gen_md_server <- function(id, board, update, session, parent, ...) {
               setupEditor();
             })();
           ",
-              editor_id,
-              editor_id
-            )))
-          )
-        },
-        priority = -100
-      )
-
-      # Update block IDs for autocomplete when blocks change
-      observe({
-        block_ids <- names(board$blocks)
-
-        # Store block IDs for validation
-        available_block_ids(block_ids)
-
-        # Get block titles from the actual board object
-        all_blocks <- board_blocks(board$board)
-        block_titles <- vapply(
-          all_blocks[block_ids],
-          block_name,
-          character(1)
-        )
-
-        # Create completion list with full markdown image syntax
-        # Use block titles as keys (shown as meta labels in autocomplete)
-        completions <- paste0("![](blockr://", block_ids, ")")
-        names(completions) <- block_titles
-        completion_list <- as.list(completions)
-
-        # Update autocomplete list
-        shinyAce::updateAceEditor(
-          session,
-          "ace",
-          autoCompleters = c("static"),
-          autoCompleteList = completion_list
-        )
-
-        # Update again after a delay to ensure it takes effect on first load
-        later::later(
-          function() {
-            shinyAce::updateAceEditor(
-              session,
-              "ace",
-              autoCompleters = c("static"),
-              autoCompleteList = completion_list
+                editor_id,
+                editor_id
+              )))
             )
           },
-          delay = 1
+          priority = -100
         )
-      })
 
-      observeEvent(
-        get_board_option_or_default("dark_mode"),
-        shinyAce::updateAceEditor(
-          session,
-          "ace",
-          theme = ace_theme()
+        # Update block IDs for autocomplete when blocks change
+        observe({
+          block_ids <- names(board$blocks)
+
+          # Store block IDs for validation
+          available_block_ids(block_ids)
+
+          # Get block titles from the actual board object
+          all_blocks <- board_blocks(board$board)
+          block_titles <- vapply(
+            all_blocks[block_ids],
+            block_name,
+            character(1)
+          )
+
+          # Create completion list with full markdown image syntax
+          # Use block titles as keys (shown as meta labels in autocomplete)
+          completions <- paste0("![](blockr://", block_ids, ")")
+          names(completions) <- block_titles
+          completion_list <- as.list(completions)
+
+          # Update autocomplete list
+          shinyAce::updateAceEditor(
+            session,
+            "ace",
+            autoCompleters = c("static"),
+            autoCompleteList = completion_list
+          )
+
+          # Update again after a delay to ensure it takes effect on first load
+          later::later(
+            function() {
+              shinyAce::updateAceEditor(
+                session,
+                "ace",
+                autoCompleters = c("static"),
+                autoCompleteList = completion_list
+              )
+            },
+            delay = 1
+          )
+        })
+
+        observeEvent(
+          get_board_option_or_default("dark_mode"),
+          shinyAce::updateAceEditor(
+            session,
+            "ace",
+            theme = ace_theme()
+          )
         )
-      )
 
-      res_tpl <- reactive(
-        {
-          inp_temp <- input$template
-
-          if (isTruthy(input$use_custom_template) && isTruthy(inp_temp)) {
-            inp_temp$datapath
-          } else if (isTruthy(input$template_select)) {
-            input$template_select
-          } else {
-            pkg_file("templates", "pandoc-default.pptx")
-          }
-        }
-      )
-
-      extract_block_ids <- function(markdown_text) {
-        if (length(markdown_text) == 0 || nchar(markdown_text) == 0) {
-          return(character())
-        }
-
-        # Extract all blockr:// references using regex
-        pattern <- "blockr://([a-zA-Z0-9_]+)"
-        matches <- gregexpr(pattern, markdown_text, perl = TRUE)
-
-        if (matches[[1]][1] == -1) {
-          return(character())
-        }
-
-        # Extract the captured groups (block IDs)
-        all_matches <- regmatches(markdown_text, matches)[[1]]
-        # Remove the "blockr://" prefix
-        block_ids <- gsub("^blockr://", "", all_matches)
-        unique(block_ids)
-      }
-
-      # Debounced reactive for markdown content
-      markdown_debounced <- debounce(
-        reactive(
+        res_tpl <- reactive(
           {
-            input$ace
+            inp_temp <- input$template
+
+            if (isTruthy(input$use_custom_template) && isTruthy(inp_temp)) {
+              inp_temp$datapath
+            } else if (isTruthy(input$template_select)) {
+              input$template_select
+            } else {
+              pkg_file("templates", "pandoc-default.pptx")
+            }
           }
-        ),
-        300
-      )
-
-      # Validate block IDs when markdown changes (debounced)
-      observe({
-        markdown <- markdown_debounced()
-
-        if (length(markdown) == 0 || nchar(markdown) == 0) {
-          validation_message("")
-          return()
-        }
-
-        # Extract block IDs from markdown
-        used_ids <- extract_block_ids(markdown)
-
-        if (length(used_ids) == 0) {
-          validation_message("")
-          return()
-        }
-
-        # Check which IDs are invalid
-        available_ids <- available_block_ids()
-        invalid_ids <- setdiff(used_ids, available_ids)
-
-        if (length(invalid_ids) > 0) {
-          msg <- sprintf(
-            "Warning: Invalid block ID%s: %s",
-            if (length(invalid_ids) > 1) "s" else "",
-            paste(invalid_ids, collapse = ", ")
-          )
-          validation_message(msg)
-        } else {
-          validation_message("")
-        }
-      })
-
-      # Render validation message
-      output$validation_message <- renderUI({
-        msg <- validation_message()
-
-        if (nchar(msg) == 0) {
-          return(NULL)
-        }
-
-        div(
-          class = "alert alert-danger",
-          role = "alert",
-          style = paste0(
-            "margin-top: -5px; margin-bottom: 10px; ",
-            "padding: 8px 12px; font-size: 0.875rem;"
-          ),
-          tags$strong("Error: "),
-          gsub("^Warning: ", "", msg)
         )
-      })
 
-      output$dl_ppt <- downloadHandler(
-        filename = function() {
-          paste0(
-            "topline_",
-            format(Sys.time(), "%Y-%m-%d_%H-%M-%S"),
-            ".pptx"
+        extract_block_ids <- function(markdown_text) {
+          if (length(markdown_text) == 0 || nchar(markdown_text) == 0) {
+            return(character())
+          }
+
+          # Extract all blockr:// references using regex
+          pattern <- "blockr://([a-zA-Z0-9_]+)"
+          matches <- gregexpr(pattern, markdown_text, perl = TRUE)
+
+          if (matches[[1]][1] == -1) {
+            return(character())
+          }
+
+          # Extract the captured groups (block IDs)
+          all_matches <- regmatches(markdown_text, matches)[[1]]
+          # Remove the "blockr://" prefix
+          block_ids <- gsub("^blockr://", "", all_matches)
+          unique(block_ids)
+        }
+
+        # Debounced reactive for markdown content
+        markdown_debounced <- debounce(
+          reactive(
+            {
+              input$ace
+            }
+          ),
+          300
+        )
+
+        observeEvent(
+          markdown_debounced(),
+          if (!identical(content_rv(), markdown_debounced())) {
+            content_rv(markdown_debounced())
+          }
+        )
+
+        observeEvent(
+          content_rv(),
+          if (!identical(content_rv(), input$ace)) {
+            shinyAce::updateAceEditor(session, "ace", value = content_rv())
+          },
+          ignoreInit = TRUE
+        )
+
+        # Validate block IDs when markdown changes (debounced)
+        observe({
+          markdown <- content_rv()
+
+          if (length(markdown) == 0 || nchar(markdown) == 0) {
+            validation_message("")
+            return()
+          }
+
+          # Extract block IDs from markdown
+          used_ids <- extract_block_ids(markdown)
+
+          if (length(used_ids) == 0) {
+            validation_message("")
+            return()
+          }
+
+          # Check which IDs are invalid
+          available_ids <- available_block_ids()
+          invalid_ids <- setdiff(used_ids, available_ids)
+
+          if (length(invalid_ids) > 0) {
+            msg <- sprintf(
+              "Warning: Invalid block ID%s: %s",
+              if (length(invalid_ids) > 1) "s" else "",
+              paste(invalid_ids, collapse = ", ")
+            )
+            validation_message(msg)
+          } else {
+            validation_message("")
+          }
+        })
+
+        # Render validation message
+        output$validation_message <- renderUI({
+          msg <- validation_message()
+
+          if (nchar(msg) == 0) {
+            return(NULL)
+          }
+
+          div(
+            class = "alert alert-danger",
+            role = "alert",
+            style = paste0(
+              "margin-top: -5px; margin-bottom: 10px; ",
+              "padding: 8px 12px; font-size: 0.875rem;"
+            ),
+            tags$strong("Error: "),
+            gsub("^Warning: ", "", msg)
           )
-        },
-        content = function(file) {
-          req(input$ace)
+        })
 
-          # Create temp files for processing
-          ast <- tempfile(fileext = ".json")
-          tmp <- tempfile()
-          dir.create(tmp)
+        output$dl_ppt <- downloadHandler(
+          filename = function() {
+            paste0(
+              "topline_",
+              format(Sys.time(), "%Y-%m-%d_%H-%M-%S"),
+              ".pptx"
+            )
+          },
+          content = function(file) {
+            markdown <- content_rv()
+            req(markdown)
 
-          # Ensure cleanup
-          on.exit({
-            unlink(ast)
-            unlink(tmp, recursive = TRUE)
-          })
+            # Create temp files for processing
+            ast <- tempfile(fileext = ".json")
+            tmp <- tempfile()
+            dir.create(tmp)
 
-          # Process markdown to AST
-          filter_md(
-            block_filter,
-            blocks = lst_xtr(board$blocks, "server", "result"),
-            temp_dir = normalizePath(tmp),
-            doc = input$ace,
-            output = ast
-          )
+            # Ensure cleanup
+            on.exit({
+              unlink(ast)
+              unlink(tmp, recursive = TRUE)
+            })
 
-          # Determine which template to use: custom upload > function
-          # parameter > selected bundled template
-          pandoc_opts <- NULL
-          template_path <- res_tpl()
+            # Process markdown to AST
+            filter_md(
+              block_filter,
+              blocks = lst_xtr(board$blocks, "server", "result"),
+              temp_dir = normalizePath(tmp),
+              doc = markdown,
+              output = ast
+            )
 
-          if (!is.null(template_path)) {
-            trg <- file.path(dirname(file), "template.pptx")
-            file.copy(template_path, trg, overwrite = TRUE)
+            # Determine which template to use: custom upload > function
+            # parameter > selected bundled template
+            pandoc_opts <- NULL
+            template_path <- res_tpl()
 
-            on.exit(unlink(trg), add = TRUE)
+            if (!is.null(template_path)) {
+              trg <- file.path(dirname(file), "template.pptx")
+              file.copy(template_path, trg, overwrite = TRUE)
 
-            pandoc_opts <- c(
-              paste0("--reference-doc=", basename(trg)),
-              "--slide-level=2"
+              on.exit(unlink(trg), add = TRUE)
+
+              pandoc_opts <- c(
+                paste0("--reference-doc=", basename(trg)),
+                "--slide-level=2"
+              )
+            }
+
+            # Convert AST to PowerPoint
+            rmarkdown::pandoc_convert(
+              input = ast,
+              from = "json",
+              to = "pptx",
+              output = file,
+              options = pandoc_opts
             )
           }
+        )
 
-          # Convert AST to PowerPoint
-          rmarkdown::pandoc_convert(
-            input = ast,
-            from = "json",
-            to = "pptx",
-            output = file,
-            options = pandoc_opts
-          )
-        }
-      )
-
-      list(
-        state = list(content = markdown_debounced)
-      )
-    }
-  )
+        list(
+          state = list(content = content_rv)
+        )
+      }
+    )
+  }
 }

--- a/R/md-server.R
+++ b/R/md-server.R
@@ -86,19 +86,6 @@ gen_md_server <- function(content = character()) {
             autoCompleters = c("static"),
             autoCompleteList = completion_list
           )
-
-          # Update again after a delay to ensure it takes effect on first load
-          later::later(
-            function() {
-              shinyAce::updateAceEditor(
-                session,
-                "ace",
-                autoCompleters = c("static"),
-                autoCompleteList = completion_list
-              )
-            },
-            delay = 1
-          )
         })
 
         observeEvent(

--- a/tests/testthat/test-md-ext.R
+++ b/tests/testthat/test-md-ext.R
@@ -1,0 +1,7 @@
+test_that("new_md_extension opts content into external control", {
+
+  ext <- new_md_extension("# hello")
+
+  expect_true(blockr.dock::is_dock_extension(ext))
+  expect_identical(attr(ext, "external_ctrl"), "content")
+})

--- a/tests/testthat/test-md-server.R
+++ b/tests/testthat/test-md-server.R
@@ -51,3 +51,57 @@ test_that("external writes are echo-guarded and can clear the content", {
     }
   )
 })
+
+test_that("an external write is pushed to the editor when it differs", {
+
+  shiny::testServer(
+    gen_md_server(),
+    args = server_args(),
+    {
+      session$setInputs(ace = "# from editor")
+      session$elapse(400)
+
+      content_rv("# set externally")
+      session$flushReact()
+
+      expect_identical(content_rv(), "# set externally")
+    }
+  )
+})
+
+test_that("validation flags unknown block IDs and clears for plain content", {
+
+  shiny::testServer(
+    gen_md_server(),
+    args = server_args(),
+    {
+      content_rv("![](blockr://missing_block)")
+      session$flushReact()
+      expect_match(validation_message(), "missing_block")
+      expect_false(is.null(output$validation_message))
+
+      content_rv("# just a heading")
+      session$flushReact()
+      expect_identical(validation_message(), "")
+      expect_null(output$validation_message)
+    }
+  )
+})
+
+test_that("res_tpl honors an explicit selection and a custom upload", {
+
+  shiny::testServer(
+    gen_md_server(),
+    args = server_args(),
+    {
+      session$setInputs(template_select = "/sel/template.pptx")
+      expect_identical(res_tpl(), "/sel/template.pptx")
+
+      session$setInputs(
+        use_custom_template = TRUE,
+        template = list(datapath = "/up/custom.pptx")
+      )
+      expect_identical(res_tpl(), "/up/custom.pptx")
+    }
+  )
+})

--- a/tests/testthat/test-md-server.R
+++ b/tests/testthat/test-md-server.R
@@ -1,0 +1,53 @@
+server_args <- function() {
+  list(
+    board = list(blocks = list(), board = blockr.core::new_board()),
+    update = NULL,
+    session = NULL,
+    parent = NULL
+  )
+}
+
+test_that("content state is a reactiveVal seeded from the constructor", {
+
+  shiny::testServer(
+    gen_md_server("# seed"),
+    args = server_args(),
+    {
+      expect_s3_class(session$returned$state$content, "reactiveVal")
+      expect_identical(content_rv(), "# seed")
+      expect_identical(session$returned$state$content(), "# seed")
+    }
+  )
+})
+
+test_that("editor edits flow into the content state, debounced", {
+
+  shiny::testServer(
+    gen_md_server(),
+    args = server_args(),
+    {
+      session$setInputs(ace = "# edited")
+      session$elapse(400)
+
+      expect_identical(content_rv(), "# edited")
+    }
+  )
+})
+
+test_that("external writes are echo-guarded and can clear the content", {
+
+  shiny::testServer(
+    gen_md_server("# seed"),
+    args = server_args(),
+    {
+      content_rv("# external")
+      expect_identical(content_rv(), "# external")
+
+      content_rv("# external")
+      expect_identical(content_rv(), "# external")
+
+      content_rv("")
+      expect_identical(content_rv(), "")
+    }
+  )
+})


### PR DESCRIPTION
## Summary

- `content` was exposed read-only (`state = list(content = markdown_debounced)`), leaving external callers such as blockr.assistant no way to set the document text.
- Promote `content` to a read-write `reactiveVal`, seeded from the constructor and kept in sync with the Ace editor in both directions (echo-guarded) — the markdown analog of the subset block's `state -> updateTextInput` observer. `gen_md_server` becomes a factory closing over `content`, mirroring `gen_md_ui`.
- Opt into dock's external-control contract via `external_ctrl = "content"`; validation, download, and serialization now read `content_rv()`.
- Backward-compatible with dock `main` (the extra `external_ctrl` argument is absorbed harmlessly). The external-control apply path lands in BristolMyersSquibb/blockr.dock#162 (PR #163), which completes the feature end-to-end.

Fixes #23