### PR TITLE
Describe blockr:// reference syntax via extension description

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,5 +33,5 @@ Suggests:
     testthat (>= 3.0.0)
 Remotes:
     BristolMyersSquibb/blockr.core,
-    BristolMyersSquibb/blockr.dock
+    BristolMyersSquibb/blockr.dock@184-ext-description
 Config/testthat/edition: 3

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,5 +33,5 @@ Suggests:
     testthat (>= 3.0.0)
 Remotes:
     BristolMyersSquibb/blockr.core,
-    BristolMyersSquibb/blockr.dock@184-ext-description
+    BristolMyersSquibb/blockr.dock
 Config/testthat/edition: 3

--- a/R/md-ext.R
+++ b/R/md-ext.R
@@ -12,6 +12,13 @@ new_md_extension <- function(content = character(), ...) {
     gen_md_server(content),
     gen_md_ui(content),
     name = "Document",
+    description = paste0(
+      "Markdown document builder. Embed a block's rendered output by ",
+      "referencing it with markdown image syntax: ",
+      "`![caption](blockr://<block_id>)`, where `<block_id>` is the block ",
+      "id from `list_blocks` and the alt text becomes the caption. Only ",
+      "blocks on the board resolve."
+    ),
     class = "md_extension",
     external_ctrl = "content",
     ...

--- a/tests/testthat/test-md-ext.R
+++ b/tests/testthat/test-md-ext.R
@@ -5,3 +5,12 @@ test_that("new_md_extension opts content into external control", {
   expect_true(blockr.dock::is_dock_extension(ext))
   expect_identical(attr(ext, "external_ctrl"), "content")
 })
+
+test_that("new_md_extension describes the blockr:// syntax", {
+
+  desc <- blockr.dock::extension_description(new_md_extension())
+
+  expect_type(desc, "character")
+  expect_length(desc, 1L)
+  expect_match(desc, "blockr://<block_id>", fixed = TRUE)
+})


### PR DESCRIPTION
## Summary

- Supply a `description` on the Document dock extension — at the single `new_md_extension()` → `blockr.dock::new_dock_extension()` site — spelling out the `![caption](blockr://<block_id>)` embed convention, so blockr.assistant's `modify_extension` can hand the model the syntax it needs when rewriting the document.
- Pin blockr.dock to its `184-ext-description` branch, which adds the `description` argument; revert the pin once BristolMyersSquibb/blockr.dock#185 merges.

Fixes #29