### PR TITLE
Point CI workflows at BristolMyersSquibb/blockr.ci

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,7 @@ name: ci
 
 jobs:
   ci:
-    uses: cynkra/blockr.ci/.github/workflows/ci.yaml@main
+    uses: BristolMyersSquibb/blockr.ci/.github/workflows/ci.yaml@main
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       BLOCKR_PAT: ${{ secrets.BLOCKR_PAT }}

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -6,7 +6,7 @@ name: pkgdown
 
 jobs:
   pkgdown:
-    uses: cynkra/blockr.ci/.github/workflows/pkgdown.yaml@main
+    uses: BristolMyersSquibb/blockr.ci/.github/workflows/pkgdown.yaml@main
     secrets:
       BLOCKR_PAT: ${{ secrets.BLOCKR_PAT }}
     permissions:


### PR DESCRIPTION
## Summary

- Swap the reusable-workflow owner from `cynkra` to `BristolMyersSquibb` in `ci.yaml` and `pkgdown.yaml`, keeping the path and `@main` ref unchanged.
- `blockr.ci` was transferred to the BristolMyersSquibb org; the old `cynkra/blockr.ci` path resolves only through GitHub's owner redirect, which breaks silently if that name is ever reclaimed.
- Reusable-workflow and job names are unchanged, so no required-status-check or ruleset updates are needed.

Fixes #33
